### PR TITLE
Update to version 1.26.2

### DIFF
--- a/rpm/0001-Set-specific-media.role-for-pulsesink-probe.patch
+++ b/rpm/0001-Set-specific-media.role-for-pulsesink-probe.patch
@@ -15,10 +15,10 @@ stream can be distinguished from resulting stream more easily.
  1 file changed, 17 insertions(+), 1 deletion(-)
 
 diff --git a/subprojects/gst-plugins-good/ext/pulse/pulsesink.c b/subprojects/gst-plugins-good/ext/pulse/pulsesink.c
-index 348150dd87ed9ef5dcac197eec150fbec6524bbf..d029b7f17a9fc2669202357f6bd22e5ba6000d5f 100644
+index a141e8018a7bc9befdf97bfa769c1627c2e08b03..090914e77fdd9644b0df480672e2aaa275d18e4d 100644
 --- a/subprojects/gst-plugins-good/ext/pulse/pulsesink.c
 +++ b/subprojects/gst-plugins-good/ext/pulse/pulsesink.c
-@@ -2083,11 +2083,21 @@ gst_pulsesink_create_probe_stream (GstPulseSink * psink,
+@@ -2069,11 +2069,21 @@ gst_pulsesink_create_probe_stream (GstPulseSink * psink,
    pa_format_info *formats[1] = { format };
    pa_stream *stream;
    pa_stream_flags_t flags;
@@ -41,7 +41,7 @@ index 348150dd87ed9ef5dcac197eec150fbec6524bbf..d029b7f17a9fc2669202357f6bd22e5b
      goto error;
  
    /* construct the flags */
-@@ -2103,9 +2113,15 @@ gst_pulsesink_create_probe_stream (GstPulseSink * psink,
+@@ -2089,9 +2099,15 @@ gst_pulsesink_create_probe_stream (GstPulseSink * psink,
    if (!gst_pulsering_wait_for_stream_ready (psink, stream))
      goto error;
  

--- a/rpm/0002-qtmux-write-rotation-information-into-the-TKHD-matri.patch
+++ b/rpm/0002-qtmux-write-rotation-information-into-the-TKHD-matri.patch
@@ -16,10 +16,10 @@ Based on the work of Andrew den Exter <andrew.den.exter@jollamobile.com>
  3 files changed, 56 insertions(+)
 
 diff --git a/subprojects/gst-plugins-good/gst/isomp4/atoms.c b/subprojects/gst-plugins-good/gst/isomp4/atoms.c
-index 4332f861c57d0ae83bff5dc96b1748592da2a1c6..6ea3ff6c0e7cce4168f6ad2f68ec92a77b1fc3fe 100644
+index f46876f1cf3ce2e06484cca2f1352a7f61a18599..b791096f456bfccaa0f1c203f76daccd44d74e8f 100644
 --- a/subprojects/gst-plugins-good/gst/isomp4/atoms.c
 +++ b/subprojects/gst-plugins-good/gst/isomp4/atoms.c
-@@ -4458,6 +4458,37 @@ atom_trak_set_subtitle_type (AtomTRAK * trak, AtomsContext * context,
+@@ -4467,6 +4467,37 @@ atom_trak_set_subtitle_type (AtomTRAK * trak, AtomsContext * context,
    return tx3g;
  }
  
@@ -58,7 +58,7 @@ index 4332f861c57d0ae83bff5dc96b1748592da2a1c6..6ea3ff6c0e7cce4168f6ad2f68ec92a7
  atom_mfhd_init (AtomMFHD * mfhd, guint32 sequence_number)
  {
 diff --git a/subprojects/gst-plugins-good/gst/isomp4/atoms.h b/subprojects/gst-plugins-good/gst/isomp4/atoms.h
-index 5a36de954bae67913ea0c8c75b0e7953ce6b0fac..4c83ba49a4fe5d1984420b5f80c77b824472c308 100644
+index 7fa5382241604e8133886883236202eb4672fb6a..996c1152f7f3031eb57fe223d1b80f585291bc15 100644
 --- a/subprojects/gst-plugins-good/gst/isomp4/atoms.h
 +++ b/subprojects/gst-plugins-good/gst/isomp4/atoms.h
 @@ -1069,6 +1069,8 @@ SampleTableEntryMP4V * atom_trak_set_video_type (AtomTRAK * trak, AtomsContext *
@@ -71,10 +71,10 @@ index 5a36de954bae67913ea0c8c75b0e7953ce6b0fac..4c83ba49a4fe5d1984420b5f80c77b82
  atom_trak_set_timecode_type (AtomTRAK * trak, AtomsContext * context, guint trak_timescale, GstVideoTimeCode * tc);
  
 diff --git a/subprojects/gst-plugins-good/gst/isomp4/gstqtmux.c b/subprojects/gst-plugins-good/gst/isomp4/gstqtmux.c
-index 517f1fd4de7e0e0459ae9271971e0f50d776730e..3cecd934c3ede46f48e28ba80b07a8e4019f67b7 100644
+index acdd8a9e1ed4e19ccebf9f557326ce0802241dd4..42da827054ad414a7c984ed9b71f24dede59bfeb 100644
 --- a/subprojects/gst-plugins-good/gst/isomp4/gstqtmux.c
 +++ b/subprojects/gst-plugins-good/gst/isomp4/gstqtmux.c
-@@ -7058,6 +7058,7 @@ gst_qt_mux_sink_event (GstAggregator * agg, GstAggregatorPad * agg_pad,
+@@ -7153,6 +7153,7 @@ gst_qt_mux_sink_event (GstAggregator * agg, GstAggregatorPad * agg_pad,
        GstTagSetter *setter = GST_TAG_SETTER (qtmux);
        GstTagMergeMode mode;
        gchar *code;
@@ -82,7 +82,7 @@ index 517f1fd4de7e0e0459ae9271971e0f50d776730e..3cecd934c3ede46f48e28ba80b07a8e4
  
        GST_OBJECT_LOCK (qtmux);
        mode = gst_tag_setter_get_tag_merge_mode (setter);
-@@ -7096,6 +7097,28 @@ gst_qt_mux_sink_event (GstAggregator * agg, GstAggregatorPad * agg_pad,
+@@ -7191,6 +7192,28 @@ gst_qt_mux_sink_event (GstAggregator * agg, GstAggregatorPad * agg_pad,
          g_free (code);
        }
  

--- a/rpm/gst-plugins-good.spec
+++ b/rpm/gst-plugins-good.spec
@@ -5,11 +5,11 @@
 %global _vpath_builddir subprojects/gst-plugins-good/_build
 
 Name:           %{gstreamer}%{majorminor}-plugins-good
-Version:        1.24.10
+Version:        1.26.2
 Release:        1
 Summary:        GStreamer plug-ins with good code and licensing
 License:        LGPLv2+
-URL:            http://gstreamer.freedesktop.org/
+URL:            https://github.com/sailfishos/gst-plugins-good
 Source:         %{name}-%{version}.tar.xz
 Patch0:         0001-Set-specific-media.role-for-pulsesink-probe.patch
 Patch1:         0002-qtmux-write-rotation-information-into-the-TKHD-matri.patch
@@ -54,32 +54,32 @@ plug-ins.
 %meson \
   -Dpackage-name='SailfishOS GStreamer package plugins (good set)' \
   -Dpackage-origin='http://sailfishos.org/' \
-  -Dnls=disabled \
-  -Ddoc=disabled \
-  -Dexamples=disabled \
-  -Dorc=enabled \
-  -Dvpx=enabled \
-  -Dv4l2-probe=false \
-  -Dv4l2-libv4l2=disabled \
-  -Doss=disabled -Doss4=disabled \
-  -Dy4m=disabled \
-  -Dtaglib=disabled \
-  -Dqt5=disabled \
-  -Dqt6=disabled \
-  -Dximagesrc=disabled \
   -Daalib=disabled \
   -Damrnb=disabled \
   -Damrwbdec=disabled \
+  -Ddoc=disabled \
+  -Ddv=disabled \
+  -Ddv1394=disabled \
+  -Dexamples=disabled \
   -Dgdk-pixbuf=disabled -Dgtk3=disabled \
   -Djack=disabled \
   -Dlame=disabled -Dtwolame=disabled \
   -Dlibcaca=disabled \
-  -Ddv=disabled \
-  -Ddv1394=disabled \
-  -Dshout2=disabled \
-  -Dwavpack=disabled \
   -Dmonoscope=disabled \
-  -Drpicamsrc=disabled
+  -Dnls=disabled \
+  -Dorc=enabled \
+  -Doss=disabled -Doss4=disabled \
+  -Dqt5=disabled \
+  -Dqt6=disabled \
+  -Drpicamsrc=disabled \
+  -Dshout2=disabled \
+  -Dtaglib=disabled \
+  -Dv4l2-probe=false \
+  -Dv4l2-libv4l2=disabled \
+  -Dvpx=enabled \
+  -Dwavpack=disabled \
+  -Dximagesrc=disabled \
+  -Dy4m=disabled
 
 %meson_build
 


### PR DESCRIPTION
Use packaging URL in spec. Sort meson options alphabetically.